### PR TITLE
Add vshard into tracked repos back

### DIFF
--- a/docbot/settings.py
+++ b/docbot/settings.py
@@ -8,6 +8,7 @@ title_header = 'Title:'
 api = 'https://api.github.com/repos/tarantool/'
 doc_repo_urls = {
     'tarantool/tarantool': f'{api}doc',
+    'tarantool/vshard': f'{api}doc',
     'tarantool/tarantool-ee': f'{api}enterprise_doc',
     'tarantool/sdk': f'{api}enterprise_doc',
     'tarantool/tdg': f'{api}tdg-doc',


### PR DESCRIPTION
The problem is mentioned in #14, but I'll leave the issue open, because the original problem is still here.

It seems the regression was introduced in f1df824a7922 ("Refactor docbot service").