### PR TITLE
Add prometheus metrics of application and VM

### DIFF
--- a/docbot/app.py
+++ b/docbot/app.py
@@ -1,7 +1,9 @@
 from elasticapm.contrib.flask import ElasticAPM
+from prometheus_flask_exporter import PrometheusMetrics
 from flask import Flask, request
 
 from .handlers import webhook_handler, list_events_handler
+
 
 app = Flask(__name__)
 
@@ -10,6 +12,7 @@ app.config['ELASTIC_APM'] = {
 }
 apm = ElasticAPM(app)
 
+metrics = PrometheusMetrics(app)
 
 @app.route("/", methods=['GET'])
 def index() -> str:
@@ -17,6 +20,11 @@ def index() -> str:
 
 
 @app.route("/", methods=['POST'])
+@metrics.summary(
+    name='events',
+    description='Summary of event from the GitHub service',
+    labels={'event': lambda: request.headers.get('X-GitHub-Event', None)}
+)
 def webhook() -> str:
     data: dict = request.json
     event: str = request.headers.get('X-GitHub-Event')

--- a/docbot/github.py
+++ b/docbot/github.py
@@ -1,5 +1,6 @@
 import requests
 
+from .metrics import Metrics
 from .utils import create_event
 
 
@@ -29,6 +30,7 @@ class GitHub:
         status_code = self._send_request(url, body)
         print('Created issue: {}'.format(status_code))
 
+    @Metrics.github_latency.time()
     def _send_request(self, url, body, method='post'):
         headers = {
             'Authorization': 'token {}'.format(self.token),

--- a/docbot/metrics.py
+++ b/docbot/metrics.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from prometheus_client import Histogram
+
+
+@dataclass
+class Metrics:
+    github_latency = Histogram(
+        name='github',
+        documentation='Time spent processing a request from the GitHub service'
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ idna==3.3
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
+prometheus-flask-exporter==0.22.3
 requests==2.28.0
 urllib3==1.26.9
 Werkzeug==2.1.2


### PR DESCRIPTION
A new `GET /metrics` endpoint has been added with a basic metrics.

Two custom metrics have also been added:
- event types (X-GitHub-Event);
- request latency from a third-party service (Github).

Closes #27