### PR TITLE
Add request verification to the webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker build -t docbot .
 Then run it like this:
 
 ```sh
-docker run -d -p5000:5000 -e GITHUB_TOKEN=<token> --name docbot docbot
+docker run -d -p5000:5000 -e GITHUB_TOKEN=<token> -e GITHUB_SIGN_KEY=<sign_key> --name docbot docbot
 ```
 
 To check that it works try to get `localhost:5000` - it will print the

--- a/docbot/settings.py
+++ b/docbot/settings.py
@@ -1,7 +1,9 @@
 import os
 
 token = os.environ.get('GITHUB_TOKEN')
+github_signature = os.environ.get('GITHUB_SIGN_KEY')
 assert token is not None
+assert github_signature is not None
 doc_requests = [' document\r\n', ' document\n']
 bot_name = '@TarantoolBot'
 title_header = 'Title:'

--- a/docbot/utils.py
+++ b/docbot/utils.py
@@ -1,4 +1,6 @@
 import datetime
+import hashlib
+import hmac
 
 from . import settings
 
@@ -16,3 +18,24 @@ def create_event(author, action, body):
     last_events.append(result)
     if len(last_events) > settings.LAST_EVENTS_SIZE:
         last_events.pop(0)
+
+def is_verified_signature(body, signature):
+    """Verify that the payload was sent from GitHub by validating SHA256.
+    
+    Returns True if the request is authorized, otherwise False.
+    
+    Args:
+        body: original request body to verify
+        signature: header received from GitHub
+    """
+    if not signature:
+        return False
+    hash_object = hmac.new(
+        settings.github_signature.encode('utf-8'),
+        msg=body,
+        digestmod=hashlib.sha256
+    )
+    expected_signature = "sha256=" + hash_object.hexdigest()
+    if not hmac.compare_digest(expected_signature, signature):
+        return False
+    return True


### PR DESCRIPTION
### Description

Now the service checks the request and its source. If the source of the request is not `GitHub` or the request does not contain the correct value in the headers by the key `X-Hub-Signature-256`, then the route of the webhook (`POST /`) will respond `403 Forbidden`.

The validate is performed in accordance with [this guide](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks) from Github.

### What's new in the administration

Previously, the service used a Github token from an `GITHUB_TOKEN` environment variable.
Now the service requires an **additional secret** token from the environment variables using the `GITHUB_SIGN_KEY` key. See [this guide](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks#setting-your-secret-token).

If `GITHUB_TOKEN` not set, will be raised an exception:
```python
  File "/home/pc/workspace/vk/docbot/docbot/settings.py", line 5, in <module>
    assert token is not None
AssertionError
```
if `GITHUB_SIGN_KEY` not set, will be raised an exception:
```python
  File "/home/pc/workspace/vk/docbot/docbot/settings.py", line 6, in <module>
    assert github_signature is not None
AssertionError
```

### Examples

<details>
  <summary>cURL request with correct signature: expected 200;</summary>

  ```bash
    curl --location --request POST 'http://0.0.0.0:8000/' \
    --header 'X-Github-Event: issue_comment' \
    --header 'X-GitHub-Delivery: example_delivery' \
    --header 'X-Hub-Signature-256: some_correct_value' \
    --header 'Content-Type: application/json' \
    --data-raw '{
    "issue": {
        "state": "open",
        "url": "http://0.0.0.0:8000", <-- change it
        "html_url": "http://0.0.0.0:8000" <-- change it
    },
    "repository": {"test" :"bugbounty", "full_name": "test"},
    "action": "created",
    "comment": {
        "body": "@TarantoolBotdocument\r\nTitle:fdsf",
        "user": { "login" : "test"}
    }
}'
  ```
</details>



<details>
  <summary>cURL request without signature: expected 403;</summary>

  ```bash
    curl --location --request POST 'http://0.0.0.0:8000/' \
    --header 'X-Github-Event: issue_comment' \
    --header 'X-GitHub-Delivery: example_delivery' \
    --header 'Content-Type: application/json' \
    --data-raw '{
    "issue": {
        "state": "open",
        "url": "http://0.0.0.0:8000", <-- change it
        "html_url": "http://0.0.0.0:8000" <-- change it
    },
    "repository": {"test" :"bugbounty", "full_name": "test"},
    "action": "created",
    "comment": {
        "body": "@TarantoolBotdocument\r\nTitle:fdsf",
        "user": { "login" : "test"}
    }
}'
  ```
</details>

<details>
  <summary>cURL request with bad signature: expected 403;</summary>

  ```bash
    curl --location --request POST 'http://0.0.0.0:8000/' \
    --header 'X-Github-Event: issue_comment' \
    --header 'X-GitHub-Delivery: example_delivery' \
    --header 'X-Hub-Signature-256: haha' \
    --header 'Content-Type: application/json' \
    --data-raw '{
    "issue": {
        "state": "open",
        "url": "http://0.0.0.0:8000", <-- change it
        "html_url": "http://0.0.0.0:8000" <-- change it
    },
    "repository": {"test" :"bugbounty", "full_name": "test"},
    "action": "created",
    "comment": {
        "body": "@TarantoolBotdocument\r\nTitle:fdsf",
        "user": { "login" : "test"}
    }
}'
  ```
</details>


[1] tarantool/security#124