### PR TITLE
Add grouping of metrics by endpoints

### DIFF
--- a/docbot/app.py
+++ b/docbot/app.py
@@ -20,9 +20,10 @@ app.config['ELASTIC_APM'] = {
 }
 apm = ElasticAPM(app, logging=True)
 
-metrics = PrometheusMetrics(app)
+metrics = PrometheusMetrics(app, group_by='endpoint')
 
 @app.route("/", methods=['GET'])
+@metrics.do_not_track()
 def index() -> str:
     return list_events_handler()
 


### PR DESCRIPTION
Collecting metrics from each endpoint is a bad practice (if the service is on a public network, it can be attacked, scanned, etc).

Now the metrics will be grouped by handler functions and will not grow.

For example:
```python
    @app.get('/')
    def index():
        ...

    @app.post('/')
    def webhook():
        ...
```

If you try to scan/hack (i.e. send a lot of requests), you will have only two metrics for the two paths:

    flask_http_<...>{endpoint="index", method="GET", status="404"}
    flask_http_<...>{endpoint="webhook", method="GET", status="404"}

instead of N metrics for the two paths, where N is count of requests:

    flask_http_<...>{method="GET",path="/foo",status="404"}
    flask_http_<...>{method="POST",path="/bar",status="404"}

Close #34