### PR TITLE
Restrict access to metrics from the public network

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ docker build -t docbot .
 Then run it like this:
 
 ```sh
-docker run -d -p5000:5000 -e GITHUB_TOKEN=<token> -e GITHUB_SIGN_KEY=<sign_key> --name docbot docbot
+docker run \
+    -d -p5000:5000 \
+    -e GITHUB_TOKEN=<token> \
+    -e GITHUB_SIGN_KEY=<sign_key> \
+    -e PROMETHEUS_TOKEN=<token> \
+    --name docbot docbot
 ```
 
 To check that it works try to get `localhost:5000` - it will print the

--- a/docbot/settings.py
+++ b/docbot/settings.py
@@ -2,8 +2,10 @@ import os
 
 token = os.environ.get('GITHUB_TOKEN')
 github_signature = os.environ.get('GITHUB_SIGN_KEY')
+prometheus_token = os.environ.get('PROMETHEUS_TOKEN')
 assert token is not None
 assert github_signature is not None
+assert prometheus_token is not None
 doc_requests = [' document\r\n', ' document\n']
 bot_name = '@TarantoolBot'
 title_header = 'Title:'

--- a/docbot/utils.py
+++ b/docbot/utils.py
@@ -39,3 +39,15 @@ def is_verified_signature(body, signature):
     if not hmac.compare_digest(expected_signature, signature):
         return False
     return True
+
+def is_verified_prometheus_token(token):
+    """Verify that the payload was sent from Prometheus via Bearer token.
+
+    Returns True if the request is authorized, otherwise False.
+
+    Args:
+        token: original request token to verify
+    """
+    if token == settings.prometheus_token:
+        return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==8.1.3
 ecs-logging==2.0.0
 elastic-apm==6.9.1
 Flask==2.2.5
+Flask-HTTPAuth==4.8.0
 gunicorn==20.1.0
 idna==3.3
 itsdangerous==2.1.2


### PR DESCRIPTION
Due to security reasons, access to the `/metrics` endpoint is restricted by basic HTTP Bearer Token authentication. If you make a request without the correct token, the server will respond with "Unauthorized Access".

Close #43